### PR TITLE
Traits now broken with moonc v0.1.20250304+fdfcb3f1f due to USER ERROR

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ The code has been updated to support compiler:
 
 ```bash
 $ moon version --all
-moon 0.1.20250212 (cd7bfb6 2025-02-12) ~/.moon/bin/moon
-moonc v0.1.20250213+44ecf4dd9 ~/.moon/bin/moonc
-moonrun 0.1.20250212 (cd7bfb6 2025-02-12) ~/.moon/bin/moonrun
+moon 0.1.20250304 (6af90d7 2025-03-04) ~/.moon/bin/moon
+moonc v0.1.20250304+fdfcb3f1f ~/.moon/bin/moonc
+moonrun 0.1.20250304 (6af90d7 2025-03-04) ~/.moon/bin/moonrun
 ```
 
 Use `moonup` to manage `moon` compiler versions:

--- a/deflate-fast.mbt
+++ b/deflate-fast.mbt
@@ -92,7 +92,7 @@ let input_margin : Int = 16 - 1
 let min_non_literal_block_size : Int = 1 + 1 + input_margin
 
 ///|
-struct TableEntry {
+priv struct TableEntry {
   val : UInt // Value at destination
   mut offset : Int
 } derive(Show, Eq)
@@ -100,7 +100,7 @@ struct TableEntry {
 // DeflateFast maintains the table for matches,
 // and the previous byte block for cross block matching.
 ///|
-struct DeflateFast {
+priv struct DeflateFast {
   table : FixedArray[TableEntry] // [table_size]TableEntry
   mut prev : Slice[Byte] // Previous block, zero length if unknown.
   mut cur : Int // Current match offset.

--- a/deflate-fast_test.mbt
+++ b/deflate-fast_test.mbt
@@ -56,14 +56,15 @@ test "TestBestSpeed" {
         let subset = FixedArray::make(n, b'\x00')
         subset.unsafe_blit(0, abcabc, 0, n)
         let subset = Bytes::from_fixedarray(subset)
-        guard let (_, None) = want.write_bytes(subset) else {
-          e =>
-            abort(
-              "test #\{i}: want.write_bytes(subset): unexpected error: \{e}",
-            )
+        let (_, err) = want.write_bytes(subset)
+        guard err is None else {
+          abort(
+            "test #\{i}: want.write_bytes(subset): unexpected error: \{err}",
+          )
         }
-        guard let (_, None) = w.write(@io.Slice::new(subset.to_array())) else {
-          e => abort("test #\{i}: w.write(): unexpected error: \{e}")
+        let (_, err) = w.write(@io.Slice::new(subset.to_array()))
+        guard err is None else {
+          abort("test #\{i}: w.write(): unexpected error: \{err}")
         }
         // if not(flush) {
         // continue
@@ -71,16 +72,16 @@ test "TestBestSpeed" {
         // w.flush!()
       }
       let want = want.to_bytes()
-      guard let None = w.close() else {
-        e => abort("test #\{i}: w.close(): unexpected error: \{e}")
+      let err = w.close()
+      guard err is None else {
+        abort("test #\{i}: w.close(): unexpected error: \{err}")
       }
 
       //
       let got = @io.Buffer::new()
       let r : &@io.ReadCloser = &@flate.Reader::new(buf)
-      guard let (_, None) = @io.copy(got, r) else {
-        e => abort("test #\{i}: @io.copy: \{e}")
-      }
+      let (_, err) = @io.copy(got, r)
+      guard err is None else { abort("test #\{i}: @io.copy: \{err}") }
       try {
         let got = got.to_bytes()
         assert_eq!(got, want)

--- a/deflate.mbt
+++ b/deflate.mbt
@@ -41,7 +41,7 @@ let hash_mask : UInt = (1U << HASH_BITS) - 1
 // let max_hash_offset : Int = 1 << 24
 
 ///|
-struct Compressor {
+priv struct Compressor {
   w : HuffmanBitWriter
 
   // compression algorithm

--- a/deflate_test.mbt
+++ b/deflate_test.mbt
@@ -17,19 +17,19 @@ test "writer dict" {
   let text = Slice::new(b"hello again world".to_array())
   let b = @io.Buffer::new()
   let w = @flate.Writer::new(b)
-  guard let (11, None) = w.write(dict)
+  guard w.write(dict) is (11, None)
   // w.flush()
   // b.reset()
-  guard let (17, None) = w.write(text)
-  guard let None = w.close()
+  guard w.write(text) is (17, None)
+  guard w.close() is None
   let want = b.to_bytes().to_array()
   assert_eq!(38, want.length())
 
   //
   let b1 = @io.Buffer::new()
   let w = @flate.Writer::new_dict(b1, dict)
-  guard let (17, None) = w.write(text)
-  guard let None = w.close()
+  guard w.write(text) is (17, None)
+  guard w.close() is None
 
   //
   let got = b1.to_bytes().to_array()

--- a/dict-decoder.mbt
+++ b/dict-decoder.mbt
@@ -25,7 +25,7 @@
 /// For performance reasons, this implementation performs little to no sanity
 /// checks about the arguments. As such, the invariants documented for each
 /// method call must be respected.
-struct DictDecoder {
+priv struct DictDecoder {
   hist : Slice[Byte] // []byte // Sliding window history
 
   // Invariant: 0 <= rd_pos <= wr_pos <= len(hist)

--- a/flate.mbti
+++ b/flate.mbti
@@ -8,63 +8,25 @@ let ioeof : @io.IOError
 let writer_closed_error : @io.IOError
 
 // Types and methods
-type Compressor
-
 type Decompressor
-impl Decompressor {
-  close(Self) -> @io.IOError?
-  read(Self, @io.Slice[Byte]) -> (Int, @io.IOError?)
-}
-
-type DeflateFast
-impl Eq for DeflateFast
-impl Show for DeflateFast
-
-type DictDecoder
+impl @io.ReadCloser for Decompressor
 
 type DictWriter
-
-type HCode
-impl Eq for HCode
-impl Show for HCode
-
-type HuffmanBitWriter
-
-type HuffmanDecoder
-
-type HuffmanEncoder
-impl Eq for HuffmanEncoder
-impl Show for HuffmanEncoder
-
-type LevelInfo
-
-type LiteralNode
-impl Eq for LiteralNode
-impl Show for LiteralNode
-
-type StepFunc
-
-type StepState
-
-type TableEntry
-impl Eq for TableEntry
-impl Show for TableEntry
-
-type Token
-impl Show for Token
+impl @io.Writer for DictWriter
 
 type Writer
 impl Writer {
-  close(Self) -> @io.IOError?
   new(&@io.Writer) -> Self
   new_dict(&@io.Writer, @io.Slice[Byte]) -> Self
-  write(Self, @io.Slice[Byte]) -> (Int, @io.IOError?)
 }
+impl @io.WriteCloser for Writer
 
 impl Reader {
   new(&Self) -> Decompressor
   new_dict(&Self, @io.Slice[Byte]) -> Decompressor
 }
+impl @io.ByteReader for &Reader
+impl @io.Reader for &Reader
 
 // Type aliases
 
@@ -73,4 +35,5 @@ pub(open) trait Reader {
   read(Self, @io.Slice[Byte]) -> (Int, @io.IOError?)
   read_byte(Self) -> (Byte, @io.IOError?)
 }
+impl Reader for @io.Buffer
 

--- a/huffman-bit-writer.mbt
+++ b/huffman-bit-writer.mbt
@@ -75,7 +75,7 @@ let codegen_order : Array[Int] = [
 ]
 
 ///|
-struct HuffmanBitWriter {
+priv struct HuffmanBitWriter {
   // writer is the underlying writer.
   // Do not use it directly; use the write method, which ensures
   // that Write errors are sticky.

--- a/huffman-code.mbt
+++ b/huffman-code.mbt
@@ -6,7 +6,7 @@
 // license that can be found in the LICENSE file.
 
 ///|
-struct HuffmanEncoder {
+priv struct HuffmanEncoder {
   codes : Array[HCode]
   mut freqcache : Array[LiteralNode]
   bit_count : Array[Int] // [17]Int
@@ -26,21 +26,21 @@ fn HuffmanEncoder::new(size : Int) -> HuffmanEncoder {
 }
 
 ///|
-struct LiteralNode {
+priv struct LiteralNode {
   literal : UInt // uint16
   freq : Int
 } derive(Show, Eq)
 
 // HCode is a huffman code with a bit code and bit length.
 ///|
-struct HCode {
+priv struct HCode {
   mut code : UInt
   mut len : UInt
 } derive(Show, Eq)
 
 // A levelInfo describes the state of the constructed tree for a given depth.
 ///|
-struct LevelInfo {
+priv struct LevelInfo {
   // Our level.  for better printing
   level : Int
 

--- a/inflate.mbt
+++ b/inflate.mbt
@@ -234,15 +234,15 @@ pub impl @io.ByteReader for &Reader with read_byte(self) {
   self.read_byte()
 }
 
-// ///|
-// impl Reader for @io.Buffer with read(self, b) {
-//   self.read(b)
-// }
+///|
+pub impl Reader for @io.Buffer with read(self, b) {
+  self.read(b)
+}
 
-// ///|
-// impl Reader for @io.Buffer with read_byte(self) {
-//   self.read_byte()
-// }
+///|
+pub impl Reader for @io.Buffer with read_byte(self) {
+  self.read_byte()
+}
 
 // Decompress state.
 ///|

--- a/inflate.mbt
+++ b/inflate.mbt
@@ -224,6 +224,26 @@ pub(open) trait Reader {
   read_byte(Self) -> (Byte, IOError?)
 }
 
+///|
+impl @io.Reader for &Reader with read(self, b) {
+  self.read(b)
+}
+
+///|
+impl @io.ByteReader for &Reader with read_byte(self) {
+  self.read_byte()
+}
+
+// ///|
+// impl Reader for @io.Buffer with read(self, b) {
+//   self.read(b)
+// }
+
+// ///|
+// impl Reader for @io.Buffer with read_byte(self) {
+//   self.read_byte()
+// }
+
 // Decompress state.
 ///|
 struct Decompressor {
@@ -350,7 +370,8 @@ fn next_block(self : Decompressor) -> Unit {
 }
 
 ///|
-pub fn read(self : Decompressor, b : Slice[Byte]) -> (Int, IOError?) {
+// pub fn read(self : Decompressor, b : Slice[Byte]) -> (Int, IOError?) {
+pub impl @io.ReadCloser for Decompressor with read(self, b) {
   for {
     if self.to_read.length() > 0 {
       let mut n = self.to_read.length()
@@ -378,7 +399,7 @@ pub fn read(self : Decompressor, b : Slice[Byte]) -> (Int, IOError?) {
 }
 
 ///|
-pub fn Decompressor::close(self : Decompressor) -> IOError? {
+pub impl @io.ReadCloser for Decompressor with close(self) {
   if Some(ioeof) == self.err {
     return None
   }

--- a/inflate.mbt
+++ b/inflate.mbt
@@ -76,7 +76,7 @@ let huffman_count_mask = 15U
 let huffman_value_shift = 4
 
 ///|
-struct HuffmanDecoder {
+priv struct HuffmanDecoder {
   mut min : Int // the minimum code length
   mut chunks : Array[UInt] // [huffman_num_chunks]uint32 // chunks as described above
   mut links : Array[Array[UInt]] // [][]uint32               // overflow links
@@ -263,13 +263,13 @@ struct Decompressor {
 }
 
 ///|
-enum StepState {
+priv enum StepState {
   StateInit
   StateDict
 }
 
 ///|
-type StepFunc (Decompressor) -> Unit
+priv type StepFunc (Decompressor) -> Unit
 
 ///| `Reader::new` returns a new [@io.ReadCloser] that can be used
 /// to read the uncompressed version of r.
@@ -315,7 +315,7 @@ fn Decompressor::new(r : &Reader, dict : Slice[Byte]) -> Decompressor {
 fn next_block(self : Decompressor) -> Unit {
   while self.nb < 1U + 2 {
     self.err = self.more_bits()
-    guard let None = self.err else { _ => return }
+    guard self.err is None else { return }
 
   }
   self.final_flag = (self.b & 1) == 1
@@ -584,7 +584,7 @@ fn read_literal(self : Decompressor) -> Unit {
   if n > 0 {
     while self.nb < n {
       self.err = self.more_bits()
-      guard let None = self.err else { _ => return }
+      guard self.err is None else { return }
 
     }
     let mask = (1U << n.reinterpret_as_int()) - 1
@@ -599,7 +599,7 @@ fn read_literal(self : Decompressor) -> Unit {
     None => {
       while self.nb < 5 {
         self.err = self.more_bits()
-        guard let None = self.err else { _ => return }
+        guard self.err is None else { return }
 
       }
       let to_rev = ((self.b & 0x1F) << 3).to_byte()
@@ -629,7 +629,7 @@ fn read_literal(self : Decompressor) -> Unit {
     let mut extra = (dist & 1) << nb.reinterpret_as_int()
     while self.nb < nb {
       self.err = self.more_bits()
-      guard let None = self.err else { _ => return }
+      guard self.err is None else { return }
 
     }
     let mask = (1U << nb.reinterpret_as_int()) - 1

--- a/inflate.mbt
+++ b/inflate.mbt
@@ -225,12 +225,12 @@ pub(open) trait Reader {
 }
 
 ///|
-impl @io.Reader for &Reader with read(self, b) {
+pub impl @io.Reader for &Reader with read(self, b) {
   self.read(b)
 }
 
 ///|
-impl @io.ByteReader for &Reader with read_byte(self) {
+pub impl @io.ByteReader for &Reader with read_byte(self) {
   self.read_byte()
 }
 

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,8 +1,8 @@
 {
   "name": "gmlewis/flate",
-  "version": "0.35.2",
+  "version": "0.35.3",
   "deps": {
-    "gmlewis/io": "0.21.2"
+    "gmlewis/io": "0.21.3"
   },
   "readme": "README.md",
   "repository": "https://github.com/gmlewis/moonbit-flate",

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -2,7 +2,7 @@
   "name": "gmlewis/flate",
   "version": "0.35.3",
   "deps": {
-    "gmlewis/io": "0.21.3"
+    "gmlewis/io": "0.21.4"
   },
   "readme": "README.md",
   "repository": "https://github.com/gmlewis/moonbit-flate",

--- a/token.mbt
+++ b/token.mbt
@@ -59,7 +59,7 @@ let offset_codes : Array[Int] = [ // Array[UInt] // Values are always used for i
 ]
 
 ///|
-type Token UInt derive(Show)
+priv type Token UInt derive(Show)
 
 // Convert a literal into a literal token.
 ///|

--- a/writer.mbt
+++ b/writer.mbt
@@ -29,17 +29,17 @@ pub fn Writer::new_dict(w : &@io.Writer, dict : Slice[Byte]) -> Writer {
 }
 
 ///|
-struct DictWriter {
+priv struct DictWriter {
   w : &@io.Writer
 }
 
 ///|
-fn DictWriter::write(self : DictWriter, b : Slice[Byte]) -> (Int, IOError?) {
+impl @io.Writer for DictWriter with write(self, b) {
   self.w.write(b)
 }
 
 ///| `write` writes the provided data to the flate Writer.
-pub fn Writer::write(self : Writer, data : Slice[Byte]) -> (Int, IOError?) {
+pub impl @io.WriteCloser for Writer with write(self, data) {
   let data = Array::from_iter(data.iter()) // unfortunate copy
   self.d.write(Slice::new(data))
 }
@@ -47,6 +47,6 @@ pub fn Writer::write(self : Writer, data : Slice[Byte]) -> (Int, IOError?) {
 ///| `close` closes the input to the flate Writer.
 /// After closing the Writer, the compressed data can be read
 /// from the `@io.Writer` provided to `new`.
-pub fn Writer::close(self : Writer) -> IOError? {
+pub impl @io.WriteCloser for Writer with close(self) {
   self.d.close()
 }

--- a/writer.mbt
+++ b/writer.mbt
@@ -29,12 +29,12 @@ pub fn Writer::new_dict(w : &@io.Writer, dict : Slice[Byte]) -> Writer {
 }
 
 ///|
-priv struct DictWriter {
+struct DictWriter {
   w : &@io.Writer
 }
 
 ///|
-impl @io.Writer for DictWriter with write(self, b) {
+pub impl @io.Writer for DictWriter with write(self, b) {
   self.w.write(b)
 }
 


### PR DESCRIPTION
With the update to moonc v0.1.20250304+fdfcb3f1f, traits are now broken.
The latest compiler requires that you explicitly declare trait implementations using `pub impl Trait with ...` but
now fails to determine that traits are actually satisfied when traits are combined as in this usage below.

See screenshots:

![traits-2025-03-04_07-35-58](https://github.com/user-attachments/assets/13663e82-9484-4f9f-ab3e-f4407f7b3c37)

![traits-2-2025-03-04_07-36-41](https://github.com/user-attachments/assets/2774eb08-5f57-484e-89a9-edc41d98b163)

