### PR TITLE
Possible WasmGC compiler bug

### DIFF
--- a/flate.mbti
+++ b/flate.mbti
@@ -9,7 +9,8 @@ let writer_closed_error : @io.IOError
 
 // Types and methods
 type Decompressor
-impl @io.ReadCloser for Decompressor
+impl @io.Closer for Decompressor
+impl @io.Reader for Decompressor
 
 type DictWriter
 impl @io.Writer for DictWriter
@@ -19,7 +20,8 @@ impl Writer {
   new(&@io.Writer) -> Self
   new_dict(&@io.Writer, @io.Slice[Byte]) -> Self
 }
-impl @io.WriteCloser for Writer
+impl @io.Closer for Writer
+impl @io.Writer for Writer
 
 impl Reader {
   new(&Self) -> Decompressor

--- a/inflate.mbt
+++ b/inflate.mbt
@@ -370,8 +370,7 @@ fn next_block(self : Decompressor) -> Unit {
 }
 
 ///|
-// pub fn read(self : Decompressor, b : Slice[Byte]) -> (Int, IOError?) {
-pub impl @io.ReadCloser for Decompressor with read(self, b) {
+pub impl @io.Reader for Decompressor with read(self, b) {
   for {
     if self.to_read.length() > 0 {
       let mut n = self.to_read.length()
@@ -399,7 +398,7 @@ pub impl @io.ReadCloser for Decompressor with read(self, b) {
 }
 
 ///|
-pub impl @io.ReadCloser for Decompressor with close(self) {
+pub impl @io.Closer for Decompressor with close(self) {
   if Some(ioeof) == self.err {
     return None
   }

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,8 +1,8 @@
 {
   "name": "gmlewis/flate",
-  "version": "0.35.3",
+  "version": "0.35.4",
   "deps": {
-    "gmlewis/io": "0.21.4"
+    "gmlewis/io": "0.21.5"
   },
   "readme": "README.md",
   "repository": "https://github.com/gmlewis/moonbit-flate",

--- a/writer.mbt
+++ b/writer.mbt
@@ -39,7 +39,7 @@ pub impl @io.Writer for DictWriter with write(self, b) {
 }
 
 ///| `write` writes the provided data to the flate Writer.
-pub impl @io.WriteCloser for Writer with write(self, data) {
+pub impl @io.Writer for Writer with write(self, data) {
   let data = Array::from_iter(data.iter()) // unfortunate copy
   self.d.write(Slice::new(data))
 }
@@ -47,6 +47,6 @@ pub impl @io.WriteCloser for Writer with write(self, data) {
 ///| `close` closes the input to the flate Writer.
 /// After closing the Writer, the compressed data can be read
 /// from the `@io.Writer` provided to `new`.
-pub impl @io.WriteCloser for Writer with close(self) {
+pub impl @io.Closer for Writer with close(self) {
   self.d.close()
 }


### PR DESCRIPTION
Using the latest compiler:

```bash
$ moon version --all
moon 0.1.20250305 (4e6af84 2025-03-05) ~/.moon/bin/moon
moonc v0.1.20250304+fdfcb3f1f ~/.moon/bin/moonc
moonrun 0.1.20250305 (4e6af84 2025-03-05) ~/.moon/bin/moonrun
```

I updated the `gmlewis/io` package to use proper `trait` declarations, like this:

```moonbit
///| ReadWriter is the interface that groups the basic Read and Write methods.
pub(open) trait ReadWriter: Reader + Writer {}

///| ReadCloser is the interface that groups the basic Read and Close methods.
pub(open) trait ReadCloser: Reader + Closer {}
```

and now the `WasmGC` compiler reports these errors:

```
failed: moonc check /Users/glenn/src/github.com/gmlewis/moonbit-07-flate/dict-decoder.mbt /Users/glenn/src/github.com/gmlewis/moonbit-07-flate/writer.mbt /Users/glenn/src/github.com/gmlewis/moonbit-07-flate/token.mbt /Users/glenn/src/github.com/gmlewis/moonbit-07-flate/huffman-code.mbt /Users/glenn/src/github.com/gmlewis/moonbit-07-flate/bits.mbt /Users/glenn/src/github.com/gmlewis/moonbit-07-flate/simple-quicksort.mbt /Users/glenn/src/github.com/gmlewis/moonbit-07-flate/deflate.mbt /Users/glenn/src/github.com/gmlewis/moonbit-07-flate/inflate.mbt /Users/glenn/src/github.com/gmlewis/moonbit-07-flate/huffman-bit-writer.mbt /Users/glenn/src/github.com/gmlewis/moonbit-07-flate/deflate-fast.mbt -o /Users/glenn/src/github.com/gmlewis/moonbit-07-flate/target/wasm-gc/release/check/flate.mi -pkg gmlewis/flate -std-path /Users/glenn/.moon/lib/core/target/wasm-gc/release/bundle -i /Users/glenn/src/github.com/gmlewis/moonbit-07-flate/target/wasm-gc/release/check/.mooncakes/gmlewis/io/io.mi:io -pkg-sources gmlewis/flate:/Users/glenn/src/github.com/gmlewis/moonbit-07-flate -target wasm-gc
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/writer.mbt:44:3-44:7 [E1013] Warning: The type of this expression is _/0, which contains unresolved type variables. The type variable is default to Unit.
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/writer.mbt:51:3-51:7 [E1013] Warning: The type of this expression is _/0, which contains unresolved type variables. The type variable is default to Unit.
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/inflate.mbt:403:21-403:25 [E1013] Warning: The type of this expression is _/0, which contains unresolved type variables. The type variable is default to Unit.
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/writer.mbt:42:42-42:47 [E4039] There is no method write in trait @gmlewis/io.WriteCloser
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/writer.mbt:43:36-43:40 [E4015] Type _/0 has no method iter.
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/writer.mbt:44:3-44:9 [E4028] This expression has type _/0, which is a unknown type and not a record.
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/writer.mbt:50:42-50:47 [E4039] There is no method close in trait @gmlewis/io.WriteCloser
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/writer.mbt:51:3-51:9 [E4028] This expression has type _/0, which is a unknown type and not a record.
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/inflate.mbt:374:47-374:51 [E4039] There is no method read in trait @gmlewis/io.ReadCloser
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/inflate.mbt:376:8-376:20 [E4028] This expression has type _/0, which is a unknown type and not a record.
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/inflate.mbt:377:19-377:31 [E4028] This expression has type _/0, which is a unknown type and not a record.
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/inflate.mbt:378:12-378:18 [E4015] Type _/0 has no method length.
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/inflate.mbt:382:16-382:28 [E4028] This expression has type _/0, which is a unknown type and not a record.
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/inflate.mbt:384:7-384:38 [E4028] This expression has type _/0, which is a unknown type and not a record.
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/inflate.mbt:384:22-384:34 [E4028] This expression has type _/0, which is a unknown type and not a record.
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/inflate.mbt:385:10-385:22 [E4028] This expression has type _/0, which is a unknown type and not a record.
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/inflate.mbt:386:20-386:28 [E4028] This expression has type _/0, which is a unknown type and not a record.
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/inflate.mbt:390:11-390:19 [E4028] This expression has type _/0, which is a unknown type and not a record.
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/inflate.mbt:391:29-391:37 [E4028] This expression has type _/0, which is a unknown type and not a record.
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/inflate.mbt:394:6-394:15 [E4028] This expression has type _/0, which is a unknown type and not a record.
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/inflate.mbt:402:47-402:52 [E4039] There is no method close in trait @gmlewis/io.ReadCloser
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/inflate.mbt:403:21-403:29 [E4028] This expression has type _/0, which is a unknown type and not a record.
/Users/glenn/src/github.com/gmlewis/moonbit-07-flate/inflate.mbt:406:3-406:11 [E4028] This expression has type _/0, which is a unknown type and not a record.
```